### PR TITLE
Fix CIRCLE regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 dist/
 pcbasic.egg-info/
 __pycache__/
+.vscode/

--- a/pcbasic/basic/display/graphics.py
+++ b/pcbasic/basic/display/graphics.py
@@ -591,10 +591,10 @@ class Graphics(object):
             rx, _ = self._get_window_scale(r, 0.)
             ry = int(round(r * aspect))
         start_octant, start_coord, start_line = -1, -1, False
-        if start:
+        if start is not None:
             start_octant, start_coord, start_line = _get_octant(start, rx, ry)
         stop_octant, stop_coord, stop_line = -1, -1, False
-        if stop:
+        if stop is not None:
             stop_octant, stop_coord, stop_line = _get_octant(stop, rx, ry)
         if aspect == 1.:
             self._draw_circle(


### PR DESCRIPTION
This fixes #136 by explicitly checking if the `start` and `stop` angle arguments are set to `None` when calculating the octants. Previously, if one was set to `0.0`, the octant calculation for the angle in question would be skipped due to the numeric value evaluating to `False`.