### PR TITLE
fixed com ports parity issue

### DIFF
--- a/pcbasic/basic/devices/ports.py
+++ b/pcbasic/basic/devices/ports.py
@@ -12,10 +12,11 @@ import os
 import datetime
 import io
 from contextlib import contextmanager
-import platform
+
 
 from ...compat import iteritems
 from ...compat import console, stdio
+from ...compat import PY2
 
 from .devicebase import safe_io
 
@@ -34,7 +35,6 @@ from ..base import error
 from .. import values
 from .devicebase import Device, DeviceSettings, TextFileBase, RealTimeInputMixin
 from .devicebase import parse_protocol_string
-python_version = platform.python_version_tuple()
 
 
 ###############################################################################
@@ -88,8 +88,8 @@ class COMDevice(Device):
     def _parse_params(self, param):
         """Parse serial port connection parameters """
         max_param = 10
-        if python_version[0]>'2': #For python3: convert byte string into str
-            param=param.decode('latin1')
+        if not PY2: #For python3: convert byte string into str
+            param = param.decode('latin1')
         param_list = param.upper().split(',')
         if len(param_list) > max_param:
             raise error.BASICError(error.BAD_FILE_NAME)

--- a/pcbasic/basic/dos.py
+++ b/pcbasic/basic/dos.py
@@ -134,10 +134,11 @@ class Shell(object):
 
     def launch(self, command):
         """Run a SHELL subprocess."""
-        logging.debug('Executing SHELL command %r', command)
         if not self._shell:
-            logging.warning('SHELL statement not enabled: no command interpreter specified.')
+            logging.warning('SHELL statement not enabled: no command interpreter specified to run the SHELL command %r.',command)
             raise error.BASICError(error.IFC)
+        else:
+            logging.debug('Executing SHELL command %r through SHELL %r', command,str(self._shell))
         cmd = split_quoted(self._shell)
         # find executable on path
         cmd[0] = which(cmd[0], path='.' + os.pathsep + os.environ.get("PATH"))
@@ -297,4 +298,5 @@ class Shell(object):
             outstr = outstr.replace(self._enc(u'\x07'), b'')
             outstr = outstr.decode(self._encoding, errors='replace')
             outstr = self._codepage.unicode_to_bytes(outstr, errors='replace')
+            logging.debug('SHELL output: %r',outstr)
             self._console.write(outstr)

--- a/pcbasic/basic/dos.py
+++ b/pcbasic/basic/dos.py
@@ -135,10 +135,10 @@ class Shell(object):
     def launch(self, command):
         """Run a SHELL subprocess."""
         if not self._shell:
-            logging.warning('SHELL statement not enabled: no command interpreter specified to run the SHELL command %r.',command)
+            logging.warning('SHELL statement not enabled: no command interpreter specified to run the SHELL command %r.', command)
             raise error.BASICError(error.IFC)
         else:
-            logging.debug('Executing SHELL command %r through SHELL %r', command,str(self._shell))
+            logging.debug('Executing SHELL command %r through SHELL %r', command, str(self._shell))
         cmd = split_quoted(self._shell)
         # find executable on path
         cmd[0] = which(cmd[0], path='.' + os.pathsep + os.environ.get("PATH"))
@@ -298,5 +298,5 @@ class Shell(object):
             outstr = outstr.replace(self._enc(u'\x07'), b'')
             outstr = outstr.decode(self._encoding, errors='replace')
             outstr = self._codepage.unicode_to_bytes(outstr, errors='replace')
-            logging.debug('SHELL output: %r',outstr)
+            logging.debug('SHELL output: %r', outstr)
             self._console.write(outstr)

--- a/pcbasic/basic/machine.py
+++ b/pcbasic/basic/machine.py
@@ -123,7 +123,7 @@ class MachinePorts(object):
                     _, parity, bytesize, stopbits = com_port.get_params()
                     value = self.com_enable_baud_write[com_port_nr] * 0x80
                     value += self.com_break[com_port_nr] * 0x40
-                    value += {b'S': 0x38, b'M': 0x28, b'E': 0x18, b'O': 0x8, b'N': 0}[parity]
+                    value += {'S': 0x38, 'M': 0x28, 'E': 0x18, 'O': 0x8, 'N': 0}[parity]
                     if stopbits > 1:
                         value += 0x4
                     value += bytesize - 5
@@ -233,7 +233,7 @@ class MachinePorts(object):
                     # break condition
                     self.com_break[com_port_nr] = (val & 0x40) != 0
                     # parity
-                    parity = {0x38: b'S', 0x28: b'M', 0x18: b'E', 0x8: b'O', 0: b'N'}[val&0x38]
+                    parity = {0x38: 'S', 0x28: 'M', 0x18: 'E', 0x8: 'O', 0: 'N'}[val&0x38]
                     # stopbits
                     if val & 0x4:
                         # 2 or 1.5 stop bits


### PR DESCRIPTION
Hello Rob, I have been doing some tests with two vitural enviroments.
a) python 3.8.10 x32 (In theory the latest one compatible with both, win10 and win7)
b) python 2.7.18 x32 

As you suggested, I have adjusted all the port.py parameters relative to the com port configuration, from bytes to str. 
It was also needed to adjust the parity options in machine.py, inp() and _out() functions. 

To keep the python 2 retro-compatibility I implemented a python_version switcher:

```
if python_version[0]>'2': #For python3: convert byte string into str
    param=param.decode('latin1')
```

So that, the "param" variable of ports.py, _parse_params() function:

-  When running with a) venv, it comes as a bytes string, for example: b'1200,n,8,1,rs,ds,cs,cd'
  so the param=param.decode('latin1') will convert it to str: '1200,n,8,1,rs,ds,cs,cd'

 

-  When running with b) venv, it comes as a str string, for example: '1200,n,8,1,rs,ds,cs,cd'
  and it is not needed to convert it.

I tested it with my brewer instrument simulator software, and now it is communicating properly in both cases.

Two other minor changes included in this pull request, that I hope you could accept:
-In dos.py, launch() function, I have modified a debug logging line to know which SHELL is using pcbasic. (is pcbasic really using my custom shell?. Now I can check it.)
-In dos.py, _show_output(), I have added a debug logging line to print the stdout of the SHELL into the debug log file. (Is my custom shell doing what is supposed to do? Now I can check it, and register it through the log file).

Best regards
