### PR TITLE
Check for empty list when getting config

### DIFF
--- a/pcbasic/config.py
+++ b/pcbasic/config.py
@@ -494,7 +494,7 @@ class Settings(object):
         """Get value of option; choose whether to get default or None (unspecified) or '' (empty)."""
         try:
             value = self._options[name]
-            if get_default and (value is None or value == u''):
+            if get_default and (value is None or value == u'' or value == []):
                 raise KeyError
         except KeyError:
             if get_default:


### PR DESCRIPTION
This adds a check for an empty list when getting a configuration parameter, and returns the default value if found. This prevents an exception from being thrown if an invalid max-memory is passed on the command line, that is then rejected:
```
C:\Program Files (x86)\PC-BASIC 2.0>pcbasic --max-memory=65535
WARNING:root:max-memory value > 65534
WARNING:root:Value "max-memory=65535" ignored; invalid
[12:25:26.0110] WARNING: max-memory value > 65534
[12:25:26.0110] WARNING: Value "max-memory=65535" ignored; invalid
[12:25:27.0055] ERROR: Unhandled exception
Traceback (most recent call last):
  File "C:\pc-basic\pcbasic\main.py", line 29, in main
  File "C:\pc-basic\pcbasic\main.py", line 64, in run
  File "C:\pc-basic\pcbasic\main.py", line 97, in _launch_session
  File "C:\pc-basic\pcbasic\config.py", line 818, in launch_params
  File "C:\pc-basic\pcbasic\config.py", line 538, in session_params
IndexError: list index out of range
```

This change was included in #146, but seems to not have been merged. It should fix #165.