### PR TITLE
Port to Python 3.10 collections

### DIFF
--- a/pcbasic/basic/extensions.py
+++ b/pcbasic/basic/extensions.py
@@ -8,7 +8,7 @@ This file is released under the GNU GPL version 3 or later.
 
 import logging
 from importlib import import_module
-from collections import Iterable
+from collections.abc import Iterable
 
 from ..compat import text_type
 

--- a/pcbasic/basic/iostreams.py
+++ b/pcbasic/basic/iostreams.py
@@ -12,7 +12,7 @@ import sys
 import time
 import io
 from contextlib import contextmanager
-from collections import Iterable
+from collections.abc import Iterable
 
 from ..compat import WIN32, read_all_available, stdio
 from .base import signals


### PR DESCRIPTION
In Python 3.10, abstract class of collections are moved to
collections.abc. This commit fix the FTBFS for Python 3.10.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>