### PR TITLE
Add ability to selectively disable writes to devices

### DIFF
--- a/docsrc/options.html
+++ b/docsrc/options.html
@@ -355,6 +355,45 @@
             Only has an effect if combined with <code><b><a href="#--interface">--interface</a>=graphical</b></code>.
         </dd>
 
+        <dt id="--disable-writes">
+            <code><b>--disable-writes=</b>[<var>device_types</var>]</code>
+        </dt>
+        <dd>
+            Disable write operations to (n)one or more device types, as specified with <var>device_types</var>.
+            Device types for which write operations should be disabled are specified using single letters. If write 
+            operations are to be disabled for more than one device type then concatenate the device type letters, 
+            optionally separated by commas (e.g. <code>bds</code> or <code>b,d,s</code>).<br />
+            If a write operation is attempted that has been disabled with this option, a Device I/O Error (57) will
+            be triggered.<br /> 
+            The following device letters are recognized: 
+            <dl class="compact">
+                <dt><code><b>a</b></code></dt>
+                <dd>Disable writes for all device types. This is the same as specifying all other device types.</dd>
+                <dt><code><b>b</b></code></dt>
+                <dd>
+                    Disable saving programs using the <code>SAVE</code> command. If saving programs is allowed, they
+                    can also be saved to devices for which writes are otherwise disabled.
+                </dd>
+                <dt><code><b>c</b></code></dt>
+                <dd>
+                    Disable writes to the cassette device (<code>CAS1</code>). Note that the cassette (WAV) file
+                    specified with <code><b><a href="#--cas1">--cas1</a></b></code> will still be created and 
+                    initialized. 
+                </dd>
+                <dt><code><b>d</b></code></dt>
+                <dd>Disable writes to disk (files).</dd>
+                <dt><code><b>p</b></code></dt>
+                <dd>
+                    Disable writes to parallel ports. If writes to parallel ports are allowed, they can also be
+                    routed to files using <code><b><a href="#--lpt1">--lpt1</a></b></code>, 
+                    <code><b><a href="#--lpt2">--lpt2</a></b></code> and <code><b><a href="#--lpt3">--lpt3</a></b></code>,
+                    even if disk writes are otherwise disabled.
+                </dd>
+                <dt><code><b>s</b></code></dt>
+                <dd>Disable writes to serial ports.</dd>
+            </dl>
+        </dd>
+
         <dt id="--double">
             <code id="-d"><b>-d</b></code>
             <code><b>--double</b>[<b>=True</b>|<b>=False</b>]</code>

--- a/pcbasic/basic/devices/parports.py
+++ b/pcbasic/basic/devices/parports.py
@@ -203,8 +203,6 @@ class PrinterStream(io.BytesIO):
 
     def flush(self):
         """Flush the printer buffer to a printer."""
-        if not self._write_enabled:
-            raise error.BASICError(error.DEVICE_IO_ERROR)
         printbuf = self.getvalue()
         if not printbuf:
             return
@@ -214,7 +212,9 @@ class PrinterStream(io.BytesIO):
         utf8buf = self.codepage.bytes_to_unicode(
             printbuf, preserve=CONTROL,
         ).encode('utf-8', 'replace')
-        line_print(utf8buf, self.printer_name)
+        # Silently skip writing if disabled
+        if self._write_enabled:
+            line_print(utf8buf, self.printer_name)
 
     def set_control(self, select=False, init=False, lf=False, strobe=False):
         """Set the values of the control pins."""

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -53,7 +53,10 @@ class CassetteTest(TestCase):
     def test_cas_save_load(self):
         """Save and load from an existing CAS file."""
         shutil.copy(_input_file('test.cas'), _output_file('test.cas'))
-        with Session(devices={b'CAS1:': _output_file('test.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test.cas')}, 
+            enabled_writes=['save'],
+            ) as s:
             s.execute('save "cas1:empty"')
             s.execute('load "cas1:test"')
             s.execute('list')
@@ -68,7 +71,8 @@ class CassetteTest(TestCase):
         """Save and load to cassette as current device."""
         with Session(
                 devices={b'CAS1:': _output_file('test_current.cas')},
-                current_device=b'CAS1:'
+                current_device=b'CAS1:',
+                enabled_writes=['save'],
             ) as s:
             s.execute('10 ?')
             s.execute('save "Test"')
@@ -90,7 +94,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_prog.cas'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_prog.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_prog.cas')},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "cas1:prog",A')
         with Session(devices={b'CAS1:': _output_file('test_prog.cas')}) as s:
@@ -105,7 +112,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_data.cas'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.cas')},
+            enabled_writes=['cas'],
+            ) as s:
             s.execute('open "cas1:data" for output as 1')
             s.execute('print#1, 1234')
         with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
@@ -121,7 +131,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_prog.wav'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_prog.wav')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_prog.wav')},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "cas1:prog",A')
         with Session(devices={b'CAS1:': _output_file('test_prog.wav')}) as s:
@@ -134,7 +147,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_data.wav'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_data.wav')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.wav')},
+            enabled_writes=['cas'],
+            ) as s:
             s.execute('open "cas1:data" for output as 1')
             s.execute('print#1, 1234')
         with Session(devices={b'CAS1:': _output_file('test_data.wav')}) as s:
@@ -149,12 +165,18 @@ class CassetteTest(TestCase):
         except EnvironmentError:
             pass
         # create a WAV file with two programs
-        with Session(devices={b'CAS1:': _output_file('test.wav')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test.wav')},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "cas1:prog"')
             s.execute('20 A%=12345')
             s.execute('save "cas1:Prog 2",A')
-        with Session(devices={b'CAS1:': _output_file('test.wav')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test.wav')},
+            enabled_writes=['save'],
+            ) as s:
             # overwrite (part of) the first program
             s.execute('save "cas1:"')
             # load whatever is next (this should be Prog 2)
@@ -169,7 +191,10 @@ class CassetteTest(TestCase):
             pass
         # create empty file
         open(_output_file('empty.cas'), 'wb').close()
-        with Session(devices={b'CAS1:': _output_file('empty.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('empty.cas')},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('save "cas1:"')
             s.execute('load "cas1:"')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -197,7 +222,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_data.cas'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.cas')},
+            enabled_writes=['cas'],
+            ) as s:
             s.execute('open "cas1:data" for output as 1')
             s.execute('open "cas1:data" for output as 2')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -209,7 +237,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_data.cas'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.cas')},
+            enabled_writes=['cas'],
+            ) as s:
             s.execute(b'open "cas1:\x02\x01" for output as 1')
             output = [_row.strip() for _row in self.get_text(s)]
             assert output[0] == b'Bad file number\xff'
@@ -220,7 +251,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_data.cas'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.cas')},
+            enabled_writes=['cas'],
+            ) as s:
             s.execute('open "cas1:test" for random as 1')
             output = [_row.strip() for _row in self.get_text(s)]
             assert output[0] == b'Bad file mode\xff'
@@ -231,7 +265,10 @@ class CassetteTest(TestCase):
             os.remove(_output_file('test_data.cas'))
         except EnvironmentError:
             pass
-        with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.cas')},
+            enabled_writes=['cas'],
+            ) as s:
             s.execute('open "cas1:test" for output as 1')
             s.execute('? LOF(1)')
             s.execute('? LOC(1)')
@@ -240,7 +277,10 @@ class CassetteTest(TestCase):
 
     def test_cas_no_name(self):
         """Save and load to cassette without a filename."""
-        with Session(devices={b'CAS1:': _output_file('test_current.cas')}) as s:
+        with Session(
+            devices={b'CAS1:': _output_file('test_current.cas')},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 ?')
             s.execute('save "cas1:"')
         with Session(devices={b'CAS1:': _output_file('test_current.cas')}) as s:
@@ -251,6 +291,44 @@ class CassetteTest(TestCase):
             b'        .B Found.',
             b'10 PRINT',
         ]
+
+    def test_cas_save_no_save_write(self):
+        """Save to a CAS file without save enabled."""
+        try:
+            os.remove(_output_file('test_prog.cas'))
+        except EnvironmentError:
+            pass
+        with Session(
+            devices={b'CAS1:': _output_file('test_prog.cas')}, 
+            enabled_writes=['cas'],
+            ) as s:
+            s.execute('10 ?')
+            s.execute('save "cas1:prog"')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[0] == b'Device I/O error\xff'
+        with Session(devices={b'CAS1:': _output_file('test_prog.cas')}) as s:
+            s.execute('load "cas1:prog"')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[0] == b'Device Timeout\xff'
+
+    def test_cas_write_no_cas_write(self):
+        """Write to a CAS file without CAS write enabled."""
+        try:
+            os.remove(_output_file('test_data.cas'))
+        except EnvironmentError:
+            pass
+        with Session(
+            devices={b'CAS1:': _output_file('test_data.cas')}, 
+            enabled_writes=['save'],
+            ) as s:
+            s.execute('open "cas1:data" for output as 1')
+            s.execute('print#1, 1234')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[0] == b'Device I/O error\xff'
+        with Session(devices={b'CAS1:': _output_file('test_data.cas')}) as s:
+            s.execute('open "cas1:data" for input as 1')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[0] == b'Device Timeout\xff'
 
 if __name__ == '__main__':
     run_tests()

--- a/tests/unit/test_codepage.py
+++ b/tests/unit/test_codepage.py
@@ -27,6 +27,7 @@ class CodepageTest(TestCase):
         with Session(
                 codepage=cp_936, box_protect=False, textfile_encoding='utf-8',
                 devices={'c': self.output_path()},
+                enabled_writes=['disk'],
             ) as s:
             s.execute('open "c:boxtest.txt" for output as 1')
             s.execute('PRINT#1, CHR$(218);STRING$(10,CHR$(196));CHR$(191)')
@@ -48,6 +49,7 @@ class CodepageTest(TestCase):
         with Session(
                 codepage=cp_936, box_protect=True, textfile_encoding='utf-8',
                 devices={'c': self.output_path()},
+                enabled_writes=['disk'],
             ) as s:
             # to file
             s.execute('open "c:boxtest.txt" for output as 1')

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -139,7 +139,10 @@ class ConsoleTest(TestCase):
 
     def test_control_printscreen(self):
         """Test ctrl+printscreen in console."""
-        with Session(devices={'lpt1:': 'FILE:'+self.output_path(u'printscr.txt')}) as s:
+        with Session(
+            devices={'lpt1:': 'FILE:'+self.output_path(u'printscr.txt')},
+            enabled_writes=['parallel'],
+            ) as s:
             s.execute(b'cls:print "%s"' % (_LIPSUM[:200],))
             # ctrl + prtscr
             s.press_keys(u'\0\x72')

--- a/tests/unit/test_disk.py
+++ b/tests/unit/test_disk.py
@@ -21,7 +21,11 @@ class DiskTest(TestCase):
 
     def test_text(self):
         """Save and load in plaintext to a file."""
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "prog",A')
         with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
@@ -30,7 +34,11 @@ class DiskTest(TestCase):
 
     def test_binary(self):
         """Save and load in binary format to a file."""
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "prog"')
         with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
@@ -39,7 +47,11 @@ class DiskTest(TestCase):
 
     def test_protected(self):
         """Save and load in protected format to a file."""
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "prog", P')
         with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
@@ -48,7 +60,11 @@ class DiskTest(TestCase):
 
     def test_text_letter(self):
         """Save and load in plaintext to a file, explicit drive letter."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
             s.execute('10 A%=1234')
             s.execute('save "A:prog",A')
         with Session(devices={b'A': self.output_path()}) as s:
@@ -57,7 +73,11 @@ class DiskTest(TestCase):
 
     def test_files(self):
         """Test directory listing, current directory and free space report."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
             s.execute('save "A:prog",A')
             s.execute('files "A:"')
             s.execute('print "##"')
@@ -110,7 +130,10 @@ class DiskTest(TestCase):
 
     def test_internal_disk_files(self):
         """Test directory listing, current directory and free space report on special @: disk."""
-        with Session(devices={b'@': self.output_path()}) as s:
+        with Session(
+            devices={b'@': self.output_path()},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('save "@:prog",A')
             s.execute('files "@:"')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -122,7 +145,10 @@ class DiskTest(TestCase):
 
     def test_internal_disk_unbound_files(self):
         """Test directory listing, current directory and free space report on unbound @: disk."""
-        with Session(devices={}) as s:
+        with Session(
+            devices={},
+            enabled_writes=['save'],
+            ) as s:
             s.execute('save "@:prog",A')
             s.execute('files "@:"')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -135,7 +161,10 @@ class DiskTest(TestCase):
 
     def test_disk_data(self):
         """Write and read data to a text file."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for output as 1')
             s.execute('print#1, 1234')
         with Session(devices={b'A': self.output_path()}) as s:
@@ -145,14 +174,22 @@ class DiskTest(TestCase):
 
     def test_disk_data_utf8(self):
         """Write and read data to a text file, utf-8 encoding."""
-        with Session(devices={b'A': self.output_path()}, textfile_encoding='utf-8') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            textfile_encoding='utf-8',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for output as 1')
             # we're embedding codepage in this string, so should be bytes
             s.execute(b'print#1, "\x9C"')
         # utf8-sig, followed by pound sign
         with open(self.output_path('DATA'), 'rb') as f:
             assert f.read() == b'\xef\xbb\xbf\xc2\xa3\r\n\x1a'
-        with Session(devices={b'A': self.output_path()}, textfile_encoding='utf-8') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            textfile_encoding='utf-8',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for append as 1')
             s.execute(b'print#1, "\x9C"')
         with open(self.output_path('DATA'), 'rb') as f:
@@ -181,10 +218,16 @@ class DiskTest(TestCase):
 
     def test_disk_data_append(self):
         """Append data to a text file."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for output as 1')
             s.execute('print#1, 1234')
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for append as 1')
             s.execute('print#1, "abcde"')
         with Session(devices={b'A': self.output_path()}) as s:
@@ -196,13 +239,19 @@ class DiskTest(TestCase):
 
     def test_disk_random(self):
         """Write and read data to a random access file."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for random as 1')
             s.execute('field#1, 20 as a$, 20 as b$')
             s.execute('lset b$="abcde"')
             s.execute('print#1, 1234')
             s.execute('put#1, 1')
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:data" for random as 1')
             s.execute('field#1, 20 as a$, 20 as b$')
             s.execute('get#1, 1')
@@ -213,7 +262,10 @@ class DiskTest(TestCase):
         """Test case-insensitive matching of native file name."""
         # this will be case sensitive on some platforms but should be picked up correctly anyway
         open(self.output_path('MixCase.txt'), 'w').close()
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "a:mixcase.txt" for output as 1')
             s.execute('print#1, 1234')
         with Session(devices={b'A': self.output_path()}) as s:
@@ -228,7 +280,10 @@ class DiskTest(TestCase):
         """Test non-matching of names that are not ascii."""
         # this will be case sensitive on some platforms but should be picked up correctly anyway
         open(self.output_path(u'MY\xc2\xa30.02'), 'w').close()
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             # non-ascii not allowed - cp437 &h9c is pound sign
             s.execute('open "a:MY"+chr$(&h9c)+"0.02" for output as 1')
             # search for a match in the presence of non-ascii files
@@ -238,7 +293,11 @@ class DiskTest(TestCase):
 
     def test_name_illegal_chars(self):
         """Test non-matching of names that are not ascii."""
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['disk'],
+            ) as s:
             # control chars not allowed
             s.execute('open chr$(0) for output as 1')
             s.execute('open chr$(1) for output as 1')
@@ -248,7 +307,11 @@ class DiskTest(TestCase):
 
     def test_name_slash(self):
         """Test non-matching of names with forward slash."""
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['disk'],
+            ) as s:
             # forward slash not allowed
             s.execute('open "b/c" for output as 1')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -257,7 +320,10 @@ class DiskTest(TestCase):
 
     def test_unavailable_drive(self):
         """Test attempt to access unavailable drive letter."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             # drive b: not mounted
             s.execute('open "b:test" for output as 1')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -267,7 +333,11 @@ class DiskTest(TestCase):
         """Test accessing file through path."""
         os.mkdir(self.output_path('a'))
         os.mkdir(self.output_path('a', 'B'))
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['disk'],
+            ) as s:
             # simple relative path
             s.execute('open "a\\b\\rel" for output as 1:close')
             # convoluted path
@@ -287,7 +357,11 @@ class DiskTest(TestCase):
 
     def test_directory_ops(self):
         """Test directory operations."""
-        with Session(devices={b'A': self.output_path()}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('mkdir "test"')
             s.execute('mkdir "test\\test2"')
             s.execute('chdir "test"')
@@ -305,7 +379,9 @@ class DiskTest(TestCase):
         open(self.output_path('delete2.txt'), 'w').close()
         open(self.output_path('delete3'), 'w').close()
         with Session(
-                devices={b'A': self.output_path(), b'B': self.output_path()}, current_device='A:'
+            devices={b'A': self.output_path(), b'B': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['disk'],
             ) as s:
             s.execute('name "testfile" as "newname"')
             # rename across disks
@@ -363,7 +439,10 @@ class DiskTest(TestCase):
 
     def test_mount_dict_spec(self):
         """Test mount dict specification."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "A:test" for output as 1: print#1, 42: close 1')
         # lowercase
         with Session(devices={b'a': self.output_path()}) as s:
@@ -380,63 +459,100 @@ class DiskTest(TestCase):
 
     def test_bad_mount(self):
         """Test bad mount dict specification."""
-        with Session(devices={b'#': self.output_path()}) as s:
+        with Session(
+            devices={b'#': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "A:test" for output as 1: print#1, 42: close 1')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b'Path not found\xff'
-        with Session(devices={b'\0': self.output_path()}) as s:
+        with Session(
+            devices={b'\0': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "A:test" for output as 1: print#1, 42: close 1')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b'Path not found\xff'
-        with Session(devices={u'\xc4': self.output_path()}) as s:
+        with Session(
+            devices={b'\xc4': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "A:test" for output as 1: print#1, 42: close 1')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b'Path not found\xff'
 
     def test_bad_current(self):
         """Test bad current device."""
-        with Session(devices={'A': self.output_path(), 'Z': None}, current_device='B') as s:
+        with Session(
+            devices={'A': self.output_path(), 'Z': None}, 
+            current_device='B',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "test" for output as 1: print#1, 42: close 1')
         assert os.path.isfile(self.output_path('TEST'))
-        with Session(devices={'A': self.output_path(), 'Z': None}, current_device='#') as s:
+        with Session(
+            devices={'A': self.output_path(), 'Z': None}, 
+            current_device='#',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "test2" for output as 1: print#1, 42: close 1')
         assert os.path.isfile(self.output_path('TEST2'))
 
     def test_bytes_mount(self):
         """Test specifying mount dir as bytes."""
-        with Session(devices={'A': self.output_path().encode('ascii'), 'Z': None}) as s:
+        with Session(
+            devices={'A': self.output_path().encode('ascii'), 'Z': None},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "test" for output as 1: print#1, 42: close 1')
         assert os.path.isfile(self.output_path('TEST'))
         # must be ascii
-        with Session(devices={'A': b'ab\xc2', 'Z': None}) as s:
+        with Session(
+            devices={'A': b'ab\xc2', 'Z': None},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('files')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b'@:\\'
 
     def test_open_bad_device(self):
         """Test open on a bad device name."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "#:test" for output as 1: print#1, 42: close 1')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b'Bad file number\xff'
 
     def test_open_null_device(self):
         """Test the NUL device."""
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "NUL" for output as 1: print#1, 42: close 1')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b''
 
     def test_open_bad_number(self):
         """Test opening to a bad file number."""
-        with Session(devices={b'A': self.output_path()}, current_device='A') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "TEST" for output as 4')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[0] == b'Bad file number\xff'
 
     def test_open_reuse_number(self):
         """Test opening to a number taht's already in use."""
-        with Session(devices={b'A': self.output_path()}, current_device='A') as s:
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A',
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('open "TEST" for output as 1')
             s.execute('open "TEST2" for output as 1')
             output = [_row.strip() for _row in self.get_text(s)]
@@ -518,7 +634,10 @@ class DiskTest(TestCase):
         names = (b'test.y', b'verylong.ext', b'veryLongFilename.ext')
         for name in names:
             open(os.path.join(self.output_path().encode('ascii'), name), 'wb').close()
-        with Session(devices={b'A': self.output_path()}) as s:
+        with Session(
+            devices={b'A': self.output_path()},
+            enabled_writes=['disk'],
+            ) as s:
             s.execute('kill "VERYLONG.EXT"')
             assert not os.path.exists(b'verylong.ext')
             s.execute('''
@@ -528,6 +647,32 @@ class DiskTest(TestCase):
             ''')
             output = [_row.strip() for _row in self.get_text(s)]
         assert output[:3] == [b'File not found\xff']*3
+
+    def test_save_no_save_write(self):
+        """Save to a disk file without save enabled."""
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['disk'],
+            ) as s:
+            s.execute('10 ?')
+            s.execute('save "blcksav.bas"')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[0] == b'Device I/O error\xff'
+        assert not os.path.exists(b'blcksav.bas')
+
+    def test_disk_write_no_disk_write(self):
+        """Write to a disk file without disk write enabled."""
+        with Session(
+            devices={b'A': self.output_path()}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
+            s.execute('open "blckwrt.dat" for output as 1')
+            s.execute('print#1,12345')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[0] == b'Device I/O error\xff'
+        assert not os.path.exists(b'blckwrt.dat')
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_pickle.py
+++ b/tests/unit/test_pickle.py
@@ -41,7 +41,10 @@ class PickleTest(TestCase):
 
     def test_pickle_session_open_file(self):
         """Pickle Session object with open file."""
-        s = Session(devices={'a': self.output_path()})
+        s = Session(
+            devices={'a': self.output_path()},
+            enabled_writes=['disk'],
+            )
         s.execute('open "A:TEST" for output as 1')
         ps = pickle.dumps(s)
         s2 = pickle.loads(ps)

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -1,0 +1,47 @@
+"""
+PC-BASIC test.disk
+Tests for disk devices
+
+(c) 2020--2021 Rob Hagemans
+This file is released under the GNU GPL version 3 or later.
+"""
+
+import unittest
+import os
+import platform
+
+from pcbasic import Session
+from tests.unit.utils import TestCase, run_tests
+
+
+class PortsTest(TestCase):
+    """Parallel and serial ports tests."""
+
+    tag = u'ports'
+
+    def test_write_enabled(self):
+        """Write to serial and parallel ports with writes enabled."""
+        with Session(
+            devices={b'COM1:': 'STDIO:CRLF', b'LPT1:': 'STDIO:CRLF'},
+            enabled_writes=['parallel','serial'],
+        ) as s:
+            s.execute('open "com1:" for output as #1')
+            s.execute('open "lpt1:" for output as #2')
+            s.execute('print#1,"Hello "')
+            s.execute('print#2,"world!"')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[:4] == [b'']*4
+
+    def test_write_disabled(self):
+        """Write to serial and parallel ports without writes enabled."""
+        with Session(devices={b'COM1:': 'STDIO:CRLF', b'LPT1:': 'STDIO:CRLF'}) as s:
+            s.execute('open "com1:" for output as #1')
+            s.execute('open "lpt1:" for output as #2')
+            s.execute('print#1,"Hello "')
+            s.execute('print#2,"world!"')
+            output = [_row.strip() for _row in self.get_text(s)]
+        assert output[:2] == [b'Device I/O error\xff', b'Device I/O error\xff']
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/tests/unit/test_program.py
+++ b/tests/unit/test_program.py
@@ -50,10 +50,18 @@ class DiskTest(unittest.TestCase):
             b'\xf0\x81S\xf2IR%f\x0f\xc4\xd6\xc8H\xbf{\xf8_c\xcb<\xd2\x82\xd4\x04j\xd3\x06\xfa\x05'
             b'\x1a'
         )
-        with Session(devices={b'A': self._test_dir}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self._test_dir}, 
+            current_device='A:',
+            enabled_writes=['save'],
+            ) as s:
             s.execute(plaintext)
             s.execute('save "prog",P')
-        with Session(devices={b'A': self._test_dir}, current_device='A:') as s:
+        with Session(
+            devices={b'A': self._test_dir}, 
+            current_device='A:',
+            enabled_writes=['save','disk'],
+            ) as s:
             # the program saves itself as plaintext and tokenised
             # in gw-basic, illegal funcion call.
             s.execute('run "prog"')

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -153,7 +153,7 @@ class SessionTest(TestCase):
         """test Session.bind_file."""
         # open file object
         with open(self.output_path('testfile'), 'wb') as f:
-            with Session() as s:
+            with Session(enabled_writes=['disk']) as s:
                 name = s.bind_file(f)
                 # can use name as string
                 assert len(str(name)) <= 12
@@ -175,7 +175,7 @@ class SessionTest(TestCase):
             os.remove(native_name)
         except EnvironmentError:
             pass
-        with Session() as s:
+        with Session(enabled_writes=['disk']) as s:
             name = s.bind_file(native_name, create=True)
             s.execute('open "{0}" for output as 1: print#1, "test";: close'.format(name))
         with open(native_name, 'rb') as f:
@@ -194,7 +194,7 @@ class SessionTest(TestCase):
             os.remove(native_name)
         except EnvironmentError:
             pass
-        with Session() as s:
+        with Session(enabled_writes=['disk']) as s:
             name = s.bind_file(native_name, name=b'A B C', create=True)
             s.execute(b'open "@:A B C" for output as 1: print#1, "test";: close')
         with open(native_name, 'rb') as f:
@@ -206,7 +206,7 @@ class SessionTest(TestCase):
             os.remove(native_name)
         except EnvironmentError:
             pass
-        with Session() as s:
+        with Session(enabled_writes=['disk']) as s:
             name = s.bind_file(native_name, name=u'A B C', create=True)
             s.execute(u'open "@:A B C" for output as 1: print#1, "test";: close')
         with open(native_name, 'rb') as f:
@@ -273,7 +273,8 @@ class SessionTest(TestCase):
         """Test Session with ctrl print-screen copy."""
         with Session(
                 input_streams=None, output_streams=None,
-                devices={'LPT1': 'FILE:{}'.format(self.output_path('print.txt'))}
+                devices={'LPT1': 'FILE:{}'.format(self.output_path('print.txt'))},
+                enabled_writes=['parallel'],
             ) as s:
             # ctrl+printscreen
             s.press_keys(u'\0\x72')
@@ -287,7 +288,8 @@ class SessionTest(TestCase):
         """Test Session switching off ctrl print-screen copy."""
         with Session(
                 input_streams=None, output_streams=None,
-                devices={'LPT1': 'FILE:{}'.format(self.output_path('print.txt'))}
+                devices={'LPT1': 'FILE:{}'.format(self.output_path('print.txt'))},
+                enabled_writes=['parallel'],
             ) as s:
             # ctrl+printscreen
             s.press_keys(u'\0\x72\0\x72')


### PR DESCRIPTION
This is the implementation of the suggestion I made in #186. It allows the following write features to be switched on or off, independently:
- Saving programs
- Writing to cassette
- Writing to disk
- Writing to parallel ports
- Writing to serial ports
- All of the above

Configuration-wise, the user can choose to _disable_ specific writes; by default all are _enabled_. In the Sessions API, the list of write operations that are _enabled_ are specified; the default here is that all are _disabled_. This was done to explicitly allow writes internally, while making the current behaviour the default.
If writes are attempted of a type that are not allowed, a "Device I/O error" will be raised within PC-BASIC; this seems to be the only suitable I/O related error that is generic across devices. As such, it is the I/O error that all BASIC programs should be able to process, in principle.

Aside from the implementation of the feature itself:
- Documentation has been updated to include the `disable-writes` option
- Unit tests have been updated and added

All in all, I think the feature is implemented consistently, both in a functional sense and at the source code level. Getting it to work proved to be the most challenging for the cassette device. The reason is that it took me a while to figure out the relationship between cassette files, the cassette stream and the underlying format streams.

In the interest of stating the obvious: the fact I'm opening a PR means that I believe this suggestion is now ready for review, not that it's free of flaws. :)